### PR TITLE
security: disable postinstall/lifecycle scripts via .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ and breaking changes for the Business Media plugin for Grafana.
 - Replaced deprecated `npm install --only=dev` with `npm ci` in
   Playwright Dockerfile.
 
+### Project Updates
+
+- Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts and mitigate supply-chain attack risk.
+
 ## [7.3.0] - 2025-10-27
 
 ### Project Updates


### PR DESCRIPTION
## Why

Lifecycle scripts (`postinstall`, `prepare`, etc.) run arbitrary code during `npm install` and are
a common supply-chain attack vector.

## What changed

- Added `.npmrc` with `ignore-scripts=true`

## Notes

No dependencies in `package-lock.json` declare lifecycle scripts, so existing installs are
unaffected.

## References

- [npm docs](https://docs.npmjs.com/cli/v10/using-npm/scripts#a-note-on-a-common-anti-pattern)

## Test plan

- [ ] `npm install` completes successfully with `.npmrc` in place