### PR TITLE
chore: Replace yarn with npm

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node
 
 WORKDIR /app
 

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,9 +1,9 @@
-FROM node
+FROM node:22-alpine
 
 WORKDIR /app
 
 # Install dependencies
-RUN yarn add pg
+RUN npm install pg
 
 # Copy all assets and script
 COPY ./load.ts .


### PR DESCRIPTION
Node 24 (the new default for the unpinned `FROM node` image) dropped Yarn 1.x, causing `yarn add pg` to fail with "yarn: not found". Pin the base image to node:22-alpine and switch to npm install, which is always bundled with Node.