### PR TITLE
ci: migrate publish workflow to changelog validation, bump to v8.0.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,7 +55,7 @@ jobs:
           cp /tmp/pr-coverage/coverage-summary.json coverage/coverage-summary.json
 
       - name: Coverage report
-        uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2.12.0
         with:
           json-summary-compare-path: /tmp/base-coverage/coverage-summary.json
           file-coverage-mode: all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,58 +23,44 @@ on:
 permissions: {}
 
 jobs:
-  stamp-changelog:
-    name: Stamp changelog
+  check-changelog:
+    name: Check changelog
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write
+      contents: read
     steps:
-      - name: Get secrets from Vault
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
-        with:
-          vault_instance: ops
-          common_secrets: |
-            GITHUB_APP_ID=plugins-platform-bot-app:app-id
-            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
-          export_env: false
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
-        with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.branch }}
-          token: ${{ steps.app-token.outputs.token }}
-      - name: Replace [Unreleased] with version and date
+      - name: Verify CHANGELOG.md has no [Unreleased] section
         run: |
-          grep -q "## \[Unreleased\]" CHANGELOG.md || { echo "No [Unreleased] heading found \ already stamped?"; exit 1; }
-          VERSION=$(node -p "require('./package.json').version")
-          DATE=$(date -u +%Y-%m-%d)
-          sed -i "s/## \[Unreleased\]/## [$VERSION] - $DATE/" CHANGELOG.md
-      - name: Commit changelog stamp
-        env:
-          BRANCH: ${{ github.event.inputs.branch }}
-        run: |
-          git config user.name 'grafana-plugins-platform-bot[bot]'
-          git config user.email '144369747+grafana-plugins-platform-bot[bot]@users.noreply.github.com'
-          git add CHANGELOG.md
-          git diff --staged --quiet || git commit -m "chore: stamp changelog for release"
-          git push origin HEAD:$BRANCH
+          UNRELEASED_LINE=$(grep -n "^## \[Unreleased\]" CHANGELOG.md | head -1 | cut -d: -f1)
+          RELEASE_LINE=$(grep -n "^## \[[0-9]" CHANGELOG.md | head -1 | cut -d: -f1)
+
+          # No [Unreleased] section — nothing to check
+          if [ -z "$UNRELEASED_LINE" ]; then
+            exit 0
+          fi
+
+          # [Unreleased] is below the latest release — fine
+          if [ -n "$RELEASE_LINE" ] && [ "$UNRELEASED_LINE" -gt "$RELEASE_LINE" ]; then
+            exit 0
+          fi
+
+          VERSION=$(jq -r '.version' package.json)
+          echo "Error: CHANGELOG.md contains an [Unreleased] section."
+          echo "A released version is required and must match package.json (${VERSION})."
+          exit 1
 
   cd:
     name: CD
-    needs: stamp-changelog
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.3.1
+    needs: check-changelog
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
     permissions:
-      contents: write
-      pull-requests: read
-      id-token: write
       attestations: write
+      contents: write
+      id-token: write
+      pull-requests: read
     with:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v7.3.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.0
     permissions:
       contents: read
       pull-requests: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,6 @@ and breaking changes for the Business Media plugin for Grafana.
 ### Project Updates
 
 - Removed `pr-files.yml` workflow; GitHub's native Files changed tab supersedes it.
-
-### Project Updates
-
 - Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts and mitigate supply-chain attack risk.
 - Migrated publish workflow from auto-stamping changelog to pre-flight changelog validation.
 - Bumped `plugin-ci-workflows` to v8.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and breaking changes for the Business Media plugin for Grafana.
 ### Project Updates
 
 - Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts and mitigate supply-chain attack risk.
+- Migrated publish workflow from auto-stamping changelog to pre-flight changelog validation.
+- Bumped `plugin-ci-workflows` to v8.0.0.
+- Bumped `vitest-coverage-report-action` to v2.12.0.
 
 ## [7.3.0] - 2025-10-27
 


### PR DESCRIPTION
The publish workflow used to auto-stamp `CHANGELOG.md` on release — committing a version and date in place of `[Unreleased]`. That required a GitHub App token and write access, which feels like overkill for what is essentially a pre-flight check.

This PR swaps it out for a simple read-only gate: if `CHANGELOG.md` still has an `[Unreleased]` section above the latest versioned release when you trigger a deploy, the workflow fails with a clear message. You stamp the changelog yourself before releasing.

### CI/CD

- Replaced `stamp-changelog` job with `check-changelog` (read-only, no token, no git writes)
- Line-number comparison prevents false positives from `[Unreleased]` appearing in older history
- `cd` job now depends on `check-changelog`
- Bumped `plugin-ci-workflows` to `v8.0.0` in `push.yml`

### Dependencies

- Bumped `vitest-coverage-report-action` to `v2.12.0` in `coverage.yml`

## Test plan

- [ ] Trigger publish on a branch with a stamped `CHANGELOG.md` — workflow passes
- [ ] Trigger publish on a branch with an `[Unreleased]` section still present — workflow fails with a clear error
- [ ] Confirm the `cd` job runs after the changelog check passes